### PR TITLE
Feat: Add navbar to homepage and contact page

### DIFF
--- a/frontend/src/app/About/page.tsx
+++ b/frontend/src/app/About/page.tsx
@@ -3,7 +3,7 @@ import Navbar from "../../components/Navbar";
 
 export default function ContactUsPage() {
   return (
-    <main>
+    <main style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
       <Navbar />
       <About />
     </main>

--- a/frontend/src/app/ContactUs/page.tsx
+++ b/frontend/src/app/ContactUs/page.tsx
@@ -3,7 +3,7 @@ import Navbar from "../../components/Navbar";
 
 export default function ContactUsPage() {
   return (
-    <main>
+    <main style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
       <Navbar />
       <Contact />
     </main>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,9 +3,8 @@ import LandingPage from "../components/LandingPage";
 
 export default function Home() {
   return (
-    <main>
+    <main style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
       <Navbar />
-      <h1>Home</h1>
       <LandingPage />
     </main>
   );

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,3 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import styles from "../styles/navbar.module.css";
+
 export default function Navbar() {
-  return <div>Navbar</div>;
+  const pathname = usePathname();
+
+  const navItems = [
+    { label: "Home", href: "/" },
+    { label: "My Profile", href: "/profile" },
+    { label: "Volunteer", href: "/volunteer" },
+    { label: "Upcoming Events", href: "/events/upcoming" },
+    { label: "Past Events", href: "/events/past" },
+    { label: "About Us", href: "/about" },
+    { label: "Contact", href: "/ContactUs" },
+    { label: "Donate", href: "/donate" },
+  ];
+
+  return (
+    <nav className={styles.sidebar}>
+      <ul className={styles.navList}>
+        {navItems.map((item) => (
+          <li key={item.href}>
+            <Link href={item.href} className={`${styles.navLink} ${pathname === item.href ? styles.active : ""}`}>
+              {item.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <div className={styles.signOut}>
+        <button className={styles.signOutButton}>Sign Out</button>
+      </div>
+    </nav>
+  );
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -13,7 +13,7 @@ export default function Navbar() {
     { label: "Volunteer", href: "/volunteer" },
     { label: "Upcoming Events", href: "/events/upcoming" },
     { label: "Past Events", href: "/events/past" },
-    { label: "About Us", href: "/about" },
+    { label: "About Us", href: "/About" },
     { label: "Contact", href: "/ContactUs" },
     { label: "Donate", href: "/donate" },
   ];

--- a/frontend/src/styles/landingPage.module.css
+++ b/frontend/src/styles/landingPage.module.css
@@ -1,5 +1,6 @@
 .heroContainer {
   position: relative;
+  flex: 1;
   min-height: 100vh;
   background-image: url("/cat-placeholder.jpg");
   background-size: cover;
@@ -49,3 +50,9 @@
 .ctaButton:hover {
   background-color: #e6e6e6;
 }
+
+/* .pageLayout {
+  display: flex;
+  min-height: 100vh;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+} */

--- a/frontend/src/styles/navbar.module.css
+++ b/frontend/src/styles/navbar.module.css
@@ -1,0 +1,58 @@
+.sidebar {
+  width: 200px;
+  min-height: 100vh;
+  box-sizing: border-box;
+  background-color: #ffffff;
+  border-right: 1px solid #e0e0e0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 2rem 0;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.navList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.navLink {
+  display: block;
+  padding: 0.75rem 1.5rem;
+  color: #333;
+  text-decoration: none;
+  font-size: 1rem;
+  transition: background-color 0.2s ease;
+}
+
+.navLink:hover {
+  background-color: #f5f5f5;
+}
+
+.active {
+  background-color: #e6e6e6;
+  font-weight: 600;
+  border-left: 3px solid #333;
+}
+
+.signOut {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.signOutButton {
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background-color: transparent;
+  border: none;
+  color: #333;
+  font-size: 1rem;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.signOutButton:hover {
+  background-color: #f5f5f5;
+}


### PR DESCRIPTION
## Developer: Caleb So

Closes #5 

### Pull Request Summary

- Create navbar component to apply to homepage, contact page, profile, and about us page.
- The items and style sheet are subject to change
- The landing page has the navbar component, but I don't know if it should be on there
- Currently, some of the page directories are upper lower case. We may need to standardize it.

### Modifications

- frontend/src/app/page.tsx 
- frontend/src/components/Navbar.tsx 
- frontend/src/styles/landingPage.module.css 
- frontend/src/styles/navbar.module.css 
- frontend/src/app/ContactUs/page.tsx
- frontend/src/app/About/page.tsx

### Testing Considerations

- Check if each item (home, about us, profile, and contact) on the navbar leads to the correct page

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
<img width="1898" height="843" alt="Screenshot 2026-03-28 022002" src="https://github.com/user-attachments/assets/0eac646a-804f-4332-8f4e-9642ff487da5" />
<img width="1893" height="850" alt="Screenshot 2026-03-28 021923" src="https://github.com/user-attachments/assets/84f947ef-f0a6-471b-afde-e770ec30f0f8" />
<img width="1895" height="852" alt="Screenshot 2026-03-28 020009" src="https://github.com/user-attachments/assets/100c8ae5-49a2-4c6d-897b-745ce9f8209f" />
<img width="1898" height="848" alt="Screenshot 2026-03-28 015920" src="https://github.com/user-attachments/assets/145cff0b-b20b-4612-9b6e-5d8061b4ed35" />

