### PR TITLE
Implement functional Contact Us page with Resend email delivery

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,8 @@
         "mongoose": "^8.23.0",
         "next": "^16.1.6",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "resend": "^6.12.2"
       },
       "devDependencies": {
         "@types/dotenv": "^6.1.1",
@@ -1121,6 +1122,12 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -1177,6 +1184,27 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/scheduler": {
@@ -1312,6 +1340,16 @@
         }
       }
     },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
@@ -1350,6 +1388,19 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "mongoose": "^8.23.0",
     "next": "^16.1.6",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "resend": "^6.12.2"
   },
   "devDependencies": {
     "@types/dotenv": "^6.1.1",

--- a/frontend/src/app/api/contact/route.ts
+++ b/frontend/src/app/api/contact/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const ADMIN_EMAIL = process.env.CONTACT_RECIPIENT_EMAIL || "";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { firstName, lastName, email, subject, message } = body;
+
+    // Validate required fields
+    if (!firstName?.trim() || !lastName?.trim() || !email?.trim() || !subject?.trim() || !message?.trim()) {
+      return NextResponse.json({ message: "All fields are required." }, { status: 400 });
+    }
+
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return NextResponse.json({ message: "Invalid email address." }, { status: 400 });
+    }
+
+    // Checks if the admin email even exists
+    if (!ADMIN_EMAIL) {
+      console.error("[api/contact] CONTACT_RECIPIENT_EMAIL is not set.");
+      return NextResponse.json({ message: "Server configuration error." }, { status: 500 });
+    }
+
+    const { error } = await resend.emails.send({
+      from: "Much Hope Contact Form <onboarding@resend.dev>",
+      to: ADMIN_EMAIL,
+      replyTo: email,
+      subject: `Contact Form: ${subject}`,
+      html: `
+        <h2>New Contact Form Submission</h2>
+        <p><strong>Name:</strong> ${firstName} ${lastName}</p>
+        <p><strong>Email:</strong> ${email}</p>
+        <p><strong>Subject:</strong> ${subject}</p>
+        <hr />
+        <p><strong>Message:</strong></p>
+        <p>${message.replace(/\n/g, "<br/>")}</p>
+      `,
+    });
+
+    if (error) {
+      console.error("[api/contact] Resend error:", error);
+      return NextResponse.json({ message: "Failed to send email. Please try again." }, { status: 500 });
+    }
+
+    return NextResponse.json({ message: "Message sent successfully." }, { status: 200 });
+  } catch (err) {
+    console.error("[api/contact] Unexpected error:", err);
+    return NextResponse.json({ message: "An unexpected error occurred." }, { status: 500 });
+  }
+}

--- a/frontend/src/components/Contact.tsx
+++ b/frontend/src/components/Contact.tsx
@@ -10,6 +10,7 @@ export default function Contact() {
     firstName: "",
     lastName: "",
     email: "",
+    subject: "",
     message: "",
   });
 
@@ -34,7 +35,7 @@ export default function Contact() {
     e.preventDefault();
 
     // Basic validation
-    if (!formData.firstName.trim() || !formData.lastName.trim() || !formData.email.trim() || !formData.message.trim()) {
+    if (!formData.firstName.trim() || !formData.lastName.trim() || !formData.email.trim() || !formData.subject.trim() || !formData.message.trim()) {
       setSubmitStatus({
         type: "error",
         message: "Please fill in all fields.",
@@ -76,6 +77,7 @@ export default function Contact() {
           firstName: "",
           lastName: "",
           email: "",
+          subject: "",
           message: "",
         });
       } else {
@@ -145,6 +147,22 @@ export default function Contact() {
                 onChange={handleChange}
                 className={styles.input}
                 placeholder="your.email@example.com"
+                required
+              />
+            </div>
+
+            <div className={styles.formGroup}>
+              <label htmlFor="subject" className={styles.label}>
+                Subject *
+              </label>
+              <input
+                type="text"
+                id="subject"
+                name="subject"
+                value={formData.subject}
+                onChange={handleChange}
+                className={styles.input}
+                placeholder="What is this regarding?"
                 required
               />
             </div>

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -9,6 +9,7 @@ const isPublicRoute = createRouteMatcher([
   "/About",
   "/ContactUs",
   "/Donate",
+  "/api/contact",
 ]);
 
 const isAuthRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)", "/Auth/Login(.*)"]);


### PR DESCRIPTION
## Developer: Farid Rohana

Closes #55

### Pull Request Summary

Added a fully functional Contact Us form that sends submissions to the admin email via Resend.

### Modifications

Contact.tsx - added Subject field to the form (full name, email, subject, message all required with email format validation). Shows success/error message after submission.

route.ts - new Next.js API route at /api/contact that validates all fields and sends the email via Resend to the admin inbox

proxy.ts - added /api/contact to public routes so unauthenticated users can submit the form without being redirected to login

### Testing Considerations

Submit with all fields empty - should show "Please fill in all fields"
Submit with invalid email format - should show "Please enter a valid email address"
Submit with all valid fields -  should show success message and reset the form

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="1280" height="692" alt="image" src="https://github.com/user-attachments/assets/1f73dd6f-2d8a-4b75-bd35-eb0c20ac651e" />

<img width="862" height="341" alt="image" src="https://github.com/user-attachments/assets/99edde41-1d9e-4d17-85ee-8458408ab8b6" />


{put screenshots of your change, or even better a screencast displaying the functionality}
