### PR TITLE
Issue 90 replace dummy data with api fetch on past events page

### DIFF
--- a/apps/frontend/src/app/Events/PastEvents/page.tsx
+++ b/apps/frontend/src/app/Events/PastEvents/page.tsx
@@ -1,65 +1,61 @@
 "use client";
 
 // src/app/events/pastevents
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import AuthLayout from "../../AuthLayout";
 import styles from "../../../styles/pastEvents.module.css";
 import EventCard from "../../../components/EventCard";
 
-const DUMMY_PAST_EVENTS = [
-  {
-    id: "1",
-    title: "Community Meal Service",
-    date: "April 5, 2026",
-    time: "10:00 AM - 1:00 PM",
-    location: "St. James Park, San Jose",
-    description: "Help serve hot meals to members of our unhoused community.",
-  },
-  {
-    id: "2",
-    title: "Hygiene Kit Distribution",
-    date: "April 12, 2026",
-    time: "9:00 AM - 12:00 PM",
-    location: "Downtown San Jose",
-    description: "Assemble and distribute hygiene kits to those in need.",
-  },
-  {
-    id: "3",
-    title: "Clothing Drive & Sorting",
-    date: "April 19, 2026",
-    time: "11:00 AM - 3:00 PM",
-    location: "MuchHope Warehouse, San Jose",
-    description: "Sort and organize donated clothing items.",
-  },
-  {
-    id: "4",
-    title: "Resource Fair",
-    date: "April 26, 2026",
-    time: "10:00 AM - 2:00 PM",
-    location: "City Hall Plaza, San Jose",
-    description: "Connect community members with local services.",
-  },
-  {
-    id: "5",
-    title: "Build a House",
-    date: "April 28, 2026",
-    time: "10:00 AM - 8:00 PM",
-    location: "The Projects, San Jose",
-    description: "Build affordable housing.",
-  },
-];
+interface EventData {
+  id: string;
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  description: string;
+}
 
 export default function PastEventsPage() {
-  const [collapsed] = useState(false);
+  const [events, setEvents] = useState<EventData[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  async function loadEvents() {
+    try {
+      setIsLoading(true);
+      setError("");
+
+      const res = await fetch("/api/events?timeframe=past", {
+        cache: "no-store",
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) throw new Error(data.message || "Failed to load events");
+
+      setEvents(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load events");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadEvents();
+  }, []);
 
   return (
     <AuthLayout>
       <div className={styles.hero}>
         <h1 className={styles.heroTitle}>View Our Past Events!</h1>
       </div>
-      <main className={`${styles.mainContent} ${collapsed ? styles.mainContentCollapsed : styles.mainContentExpanded}`}>
+      <main className={styles.mainContent}>
+        {isLoading && <p className={styles.loadingText}>Loading past events...</p>}
+        {error && <p className={styles.errorText}>{error}</p>}
+        {!isLoading && !error && events.length === 0 && <p className={styles.emptyText}>No past events found.</p>}
         <div className={styles.eventGrid}>
-          {DUMMY_PAST_EVENTS.map((event) => (
+          {events.map((event) => (
             <EventCard key={event.id} {...event} hideMoreInfo />
           ))}
         </div>

--- a/apps/frontend/src/styles/pastEvents.module.css
+++ b/apps/frontend/src/styles/pastEvents.module.css
@@ -49,3 +49,16 @@
   gap: 1.5rem;
   max-width: 900px;
 }
+
+.loadingText,
+.errorText,
+.emptyText {
+  text-align: center;
+  padding: 2rem;
+  color: #333333;
+  font-size: 1rem;
+}
+
+.errorText {
+  color: #721c24;
+}


### PR DESCRIPTION
## Developer: Caleb So

Closes #90 

### Pull Request Summary

- Remove the DUMMY_PAST_EVENTS array
- Add a useEffect + fetch("/api/events?timeframe=past") call (same pattern as Events/Upcoming/page.tsx)
- Add loading and error states
 
### Modifications

- apps\frontend\src\app\Events\PastEvents\page.tsx
- apps\frontend\src\styles\pastEvents.module.css

### Testing Considerations

- I cannot get login to work, so I bypassed it by adding the following two lines in proxy.ts:
```
"/Events/PastEvents(.*)",
"/api/events(.*)",` 
```
- However, the fetch returns no data.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="1472" height="1226" alt="Screenshot 2026-05-10 144741" src="https://github.com/user-attachments/assets/8f9ca5ed-8e24-47ab-a915-e2c9ae43c11d" />
