### PR TITLE
fix: allow unauthenticated users to view events

### DIFF
--- a/apps/frontend/src/app/api/events/route.ts
+++ b/apps/frontend/src/app/api/events/route.ts
@@ -50,11 +50,18 @@ export async function GET(req: NextRequest) {
 
   try {
     const res = await fetch(url.toString(), { cache: "no-store" });
+
+    const contentType = res.headers.get("content-type") || "";
+    if (!contentType.includes("application/json")) {
+      console.error("[api/events] Backend returned non-JSON response:", res.status);
+      return NextResponse.json([], { status: 200 });
+    }
+
     const data = await res.json();
     const normalizedData = Array.isArray(data) ? data.map(normalizeEvent) : data;
     return NextResponse.json(normalizedData, { status: res.status });
   } catch (err) {
-    console.error("[api/event] Failed to fetch from backend:", err);
+    console.error("[api/events] Failed to fetch from backend:", err);
     return NextResponse.json([], { status: 200 });
   }
 }

--- a/apps/frontend/src/proxy.ts
+++ b/apps/frontend/src/proxy.ts
@@ -11,6 +11,8 @@ const isPublicRoute = createRouteMatcher([
   "/About",
   "/ContactUs",
   "/Donate",
+  "/Events(.*)",
+  "/api/events(.*)",
 ]);
 
 const isAuthRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)", "/auth/login(.*)", "/auth/signup(.*)"]);


### PR DESCRIPTION
Add /Events(..) and /api/events(..) to the public route matcher in middleware so unauthenticated users can browse events without being redirected to login. Also add a content-type check in the events API route to gracefully handle non-JSON responses from the backend.

## Developer: {Kai}

Closes #{104}

### Pull Request Summary

Unauthenticated users clicking "Events" in the navbar were being redirected to login instead of seeing the events page. 

## What was wrong 

Two things were blocking public access:
1. `/Events(...)` pages were not in middleware's public route list - users get redirected to `/auth/login`
2. `/api/events(...)` API route was also protected - event if the page loaded, the `fetch()` call to get event data returned an HTML login page instead of JSON, causing the "unexpected token '<'" error

### Modifications

- **`src/proxy.ts`** — Added `/Events(.*)` and `/api/events(.*)` to the `isPublicRoute` matcher
- **`src/app/api/events/route.ts`** — Added a `content-type` check before calling `.json()` so non-JSON responses (like HTML error pages) are handled gracefully instead of crashing

### Testing Considerations

1. Open `http://localhost:3000` without being logged in
2. Click "Events" in the navbar
3. Events page loads and displays events from the database
4. No redirect to login, no JSON parse errors

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers