### PR TITLE
fix: use legacy useSignUp hook, improve verification UI, add auth tests

### DIFF
--- a/apps/frontend/src/app/Auth/SignUp/page.tsx
+++ b/apps/frontend/src/app/Auth/SignUp/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useSignUp } from "@clerk/nextjs";
+import { useSignUp } from "@clerk/nextjs/legacy";
 import Signup from "../../../components/auth/Signup";
 
 export default function Page() {
   const { isLoaded, signUp, setActive } = useSignUp() as any;
+  console.log("useSignUp state:", { isLoaded, signUp: !!signUp, setActive: !!setActive });
   return <Signup signUp={signUp} setActive={setActive} isLoaded={isLoaded} />;
 }

--- a/apps/frontend/src/components/auth/Signup.tsx
+++ b/apps/frontend/src/components/auth/Signup.tsx
@@ -241,8 +241,8 @@ export default function Signup({ signUp, setActive, isLoaded }: SignupProps) {
           session: signUpAttempt.createdSessionId,
         });
 
-        // Go back to home page
-        router.push("/");
+        // Go to login page after successful signup
+        router.push("/auth/login");
       } else {
         setVerificationCodeError("Verification could not be completed. Please try again.");
       }
@@ -267,25 +267,28 @@ export default function Signup({ signUp, setActive, isLoaded }: SignupProps) {
   if (showEmailCode) {
     return (
       <div className={styles.pageContainer}>
-        <h1 className={styles.pageTitle}>Verify your email</h1>
-        <form onSubmit={handleEmailCode}>
-          <h2 className={styles.formTitle}>Enter verification code</h2>
-          <p>A verification code has been sent to {formData.email}</p>
-          <label className={styles.label}>Verification Code</label>
-          <input
-            className={styles.input}
-            type="text"
-            name="code"
-            value={code}
-            onChange={(e) => setCode(e.target.value)}
-            placeholder="Enter code"
-            inputMode="numeric"
-          />
-          {verificationCodeError && <p className={styles.error}>{verificationCodeError}</p>}
-          <button className={styles.button} type="submit" disabled={isSubmitting}>
-            {isSubmitting ? "Verifying..." : "Verify Email"}
-          </button>
-        </form>
+        <div className={styles.verificationCard}>
+          <h1 className={styles.verificationTitle}>Verify your email</h1>
+          <p className={styles.verificationSubtitle}>
+            A verification code has been sent to <strong>{formData.email}</strong>
+          </p>
+          <form onSubmit={handleEmailCode}>
+            <label className={styles.verificationLabel}>Verification Code</label>
+            <input
+              className={styles.verificationInput}
+              type="text"
+              name="code"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="Enter 6-digit code"
+              inputMode="numeric"
+            />
+            {verificationCodeError && <p className={styles.verificationError}>{verificationCodeError}</p>}
+            <button className={styles.verificationButton} type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Verifying..." : "Verify Email"}
+            </button>
+          </form>
+        </div>
       </div>
     );
   }

--- a/apps/frontend/src/components/auth/__tests__/Login.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/Login.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Login from "../Login";
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+// Mock AuthLayout to just render children
+vi.mock("@/app/AuthLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="auth-layout">{children}</div>,
+}));
+
+// Mock Clerk hooks
+const mockSignInCreate = vi.fn();
+const mockSetActive = vi.fn();
+
+let mockAuthState = { isSignedIn: false, isLoaded: true };
+let mockSignIn: any = { create: mockSignInCreate };
+
+vi.mock("@clerk/nextjs", () => ({
+  useAuth: () => mockAuthState,
+  useClerk: () => ({ setActive: mockSetActive }),
+}));
+
+vi.mock("@clerk/nextjs/legacy", () => ({
+  useSignIn: () => ({ signIn: mockSignIn }),
+}));
+
+describe("Login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthState = { isSignedIn: false, isLoaded: true };
+    mockSignIn = { create: mockSignInCreate };
+
+    // Mock window.location
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { href: "" },
+    });
+  });
+
+  it("renders the login form", () => {
+    render(<Login />);
+
+    expect(screen.getByRole("heading", { name: "Login" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
+  });
+
+  it("renders links to forgot password and signup", () => {
+    render(<Login />);
+
+    expect(screen.getByText("Forgot password?")).toBeInTheDocument();
+    expect(screen.getByText("Create Account")).toBeInTheDocument();
+  });
+
+  it("renders nothing when auth is not loaded", () => {
+    mockAuthState = { isSignedIn: false, isLoaded: false };
+
+    const { container } = render(<Login />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("redirects to home when already signed in", () => {
+    mockAuthState = { isSignedIn: true, isLoaded: true };
+
+    const { container } = render(<Login />);
+    expect(container.innerHTML).toBe("");
+    expect(mockPush).toHaveBeenCalledWith("/");
+  });
+
+  it("shows error when signIn is not loaded and form is submitted", async () => {
+    mockSignIn = null;
+
+    render(<Login />);
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "test@example.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "password123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Authentication is still loading. Please try again.")).toBeInTheDocument();
+    });
+  });
+
+  it("updates form fields on input change", () => {
+    render(<Login />);
+
+    const emailInput = screen.getByLabelText("Email") as HTMLInputElement;
+    const passwordInput = screen.getByLabelText("Password") as HTMLInputElement;
+
+    fireEvent.change(emailInput, { target: { value: "user@test.com" } });
+    fireEvent.change(passwordInput, { target: { value: "mypassword" } });
+
+    expect(emailInput.value).toBe("user@test.com");
+    expect(passwordInput.value).toBe("mypassword");
+  });
+
+  it("calls signIn.create with correct credentials on submit", async () => {
+    mockSignInCreate.mockResolvedValue({
+      status: "complete",
+      createdSessionId: "session_abc",
+    });
+    mockSetActive.mockResolvedValue({});
+
+    render(<Login />);
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "user@test.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "Password123!" } });
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    await waitFor(() => {
+      expect(mockSignInCreate).toHaveBeenCalledWith({
+        identifier: "user@test.com",
+        password: "Password123!",
+      });
+    });
+  });
+
+  it("sets active session and redirects on successful login", async () => {
+    mockSignInCreate.mockResolvedValue({
+      status: "complete",
+      createdSessionId: "session_abc",
+    });
+    mockSetActive.mockResolvedValue({});
+
+    render(<Login />);
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "user@test.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "Password123!" } });
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    await waitFor(() => {
+      expect(mockSetActive).toHaveBeenCalledWith({ session: "session_abc" });
+    });
+
+    expect(window.location.href).toBe("/");
+  });
+
+  it("shows error when sign-in status is not complete", async () => {
+    mockSignInCreate.mockResolvedValue({
+      status: "needs_second_factor",
+      createdSessionId: null,
+    });
+
+    render(<Login />);
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "user@test.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "Password123!" } });
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign-in could not be completed. Please try again.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message from Clerk on failed login", async () => {
+    mockSignInCreate.mockRejectedValue({
+      errors: [{ message: "Invalid password" }],
+    });
+
+    render(<Login />);
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "user@test.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "wrong" } });
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid password")).toBeInTheDocument();
+    });
+  });
+
+  it("shows generic error when Clerk error has no message", async () => {
+    mockSignInCreate.mockRejectedValue({
+      errors: [{}],
+    });
+
+    render(<Login />);
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "user@test.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "wrong" } });
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("An error occurred during sign in. Please try again.")).toBeInTheDocument();
+    });
+  });
+
+  it("redirects to home when user is already signed in (error message)", async () => {
+    mockSignInCreate.mockRejectedValue({
+      errors: [{ message: "You are already signed in" }],
+    });
+
+    render(<Login />);
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "user@test.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "Password123!" } });
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/");
+    });
+  });
+});

--- a/apps/frontend/src/components/auth/__tests__/Signup.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/Signup.test.tsx
@@ -1,0 +1,225 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Signup from "../Signup";
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Mock AuthLayout to just render children
+vi.mock("@/app/AuthLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="auth-layout">{children}</div>,
+}));
+
+describe("Signup", () => {
+  const mockSignUp = {
+    create: vi.fn(),
+    prepareEmailAddressVerification: vi.fn(),
+    attemptEmailAddressVerification: vi.fn(),
+  };
+  const mockSetActive = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the signup form", () => {
+    render(<Signup signUp={mockSignUp} setActive={mockSetActive} isLoaded={true} />);
+
+    expect(screen.getByText("Sign up")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Email")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Password")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Confirm Password")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign Up" })).toBeInTheDocument();
+  });
+
+  it("button is not disabled when isLoaded is false", () => {
+    render(<Signup signUp={mockSignUp} setActive={mockSetActive} isLoaded={false} />);
+
+    const button = screen.getByRole("button", { name: "Sign Up" });
+    expect(button).not.toBeDisabled();
+  });
+
+  it("shows error when isLoaded is false and form is submitted", async () => {
+    render(<Signup signUp={mockSignUp} setActive={mockSetActive} isLoaded={false} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Email"), { target: { value: "test@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("Password"), { target: { value: "Password123!" } });
+    fireEvent.change(screen.getByPlaceholderText("Confirm Password"), { target: { value: "Password123!" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign Up" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Auth is still loading. Please try again in a moment.")).toBeInTheDocument();
+    });
+
+    expect(mockSignUp.create).not.toHaveBeenCalled();
+  });
+
+  it("shows error when passwords do not match", async () => {
+    render(<Signup signUp={mockSignUp} setActive={mockSetActive} isLoaded={true} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Password"), { target: { value: "Password123!" } });
+    fireEvent.change(screen.getByPlaceholderText("Confirm Password"), { target: { value: "Different456!" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign Up" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Passwords do not match.")).toBeInTheDocument();
+    });
+
+    expect(mockSignUp.create).not.toHaveBeenCalled();
+  });
+
+  it("calls signUp.create and prepareEmailAddressVerification on successful submit", async () => {
+    mockSignUp.create.mockResolvedValue({});
+    mockSignUp.prepareEmailAddressVerification.mockResolvedValue({});
+
+    render(<Signup signUp={mockSignUp} setActive={mockSetActive} isLoaded={true} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Name"), { target: { value: "John" } });
+    fireEvent.change(screen.getByPlaceholderText("Email"), { target: { value: "john@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("Password"), { target: { value: "Password123!" } });
+    fireEvent.change(screen.getByPlaceholderText("Confirm Password"), { target: { value: "Password123!" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign Up" }));
+
+    await waitFor(() => {
+      expect(mockSignUp.create).toHaveBeenCalledWith({
+        emailAddress: "john@example.com",
+        password: "Password123!",
+        firstName: "John",
+      });
+    });
+
+    expect(mockSignUp.prepareEmailAddressVerification).toHaveBeenCalledWith({
+      strategy: "email_code",
+    });
+  });
+
+  it("shows verification code form after successful signup", async () => {
+    mockSignUp.create.mockResolvedValue({});
+    mockSignUp.prepareEmailAddressVerification.mockResolvedValue({});
+
+    render(<Signup signUp={mockSignUp} setActive={mockSetActive} isLoaded={true} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Name"), { target: { value: "John" } });
+    fireEvent.change(screen.getByPlaceholderText("Email"), { target: { value: "john@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("Password"), { target: { value: "Password123!" } });
+    fireEvent.change(screen.getByPlaceholderText("Confirm Password"), { target: { value: "Password123!" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign Up" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Verify your email")).toBeInTheDocument();
+    });
+
+    expect(screen.getByPlaceholderText("Enter 6-digit code")).toBeInTheDocument();
+    expect(screen.getByText(/A verification code has been sent to/)).toBeInTheDocument();
+  });
+
+  it("handles email verification successfully", async () => {
+    mockSignUp.create.mockResolvedValue({});
+    mockSignUp.prepareEmailAddressVerification.mockResolvedValue({});
+    mockSignUp.attemptEmailAddressVerification.mockResolvedValue({
+      status: "complete",
+      createdSessionId: "session_123",
+    });
+    mockSetActive.mockResolvedValue({});
+
+    render(<Signup signUp={mockSignUp} setActive={mockSetActive} isLoaded={true} />);
+
+    // Fill and submit signup form
+    fireEvent.change(screen.getByPlaceholderText("Name"), { target: { value: "John" } });
+    fireEvent.change(screen.getByPlaceholderText("Email"), { target: { value: "john@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("Password"), { target: { value: "Password123!" } });
+    fireEvent.change(screen.getByPlaceholderText("Confirm Password"), { target: { value: "Password123!" } });
+    fireEvent.click(screen.getByRole("button", { name: "Sign Up" }));
+
+    // Wait for verification form
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Enter 6-digit code")).toBeInTheDocument();
+    });
+
+    // Enter 6-digit code and verify
+    fireEvent.change(screen.getByPlaceholderText("Enter 6-digit code"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify Email" }));
+
+    await waitFor(() => {
+      expect(mockSignUp.attemptEmailAddressVerification).toHaveBeenCalledWith({ code: "123456" });
+    });
+
+    expect(mockSetActive).toHaveBeenCalledWith({ session: "session_123" });
+    expect(mockPush).toHaveBeenCalledWith("/auth/login");
+  });
+
+  it("shows error when signUp.create fails with known error code", async () => {
+    mockSignUp.create.mockRejectedValue({
+      errors: [{ code: "form_identifier_exists", longMessage: "", message: "" }],
+    });
+
+    render(<Signup signUp={mockSignUp} setActive={mockSetActive} isLoaded={true} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Email"), { target: { value: "existing@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("Password"), { target: { value: "Password123!" } });
+    fireEvent.change(screen.getByPlaceholderText("Confirm Password"), { target: { value: "Password123!" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign Up" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("An account with this email already exists. Try signing in instead."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when verification code is incorrect", async () => {
+    mockSignUp.create.mockResolvedValue({});
+    mockSignUp.prepareEmailAddressVerification.mockResolvedValue({});
+    mockSignUp.attemptEmailAddressVerification.mockRejectedValue({
+      errors: [{ code: "form_code_incorrect", longMessage: "", message: "" }],
+    });
+
+    render(<Signup signUp={mockSignUp} setActive={mockSetActive} isLoaded={true} />);
+
+    // Submit signup
+    fireEvent.change(screen.getByPlaceholderText("Name"), { target: { value: "John" } });
+    fireEvent.change(screen.getByPlaceholderText("Email"), { target: { value: "john@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("Password"), { target: { value: "Password123!" } });
+    fireEvent.change(screen.getByPlaceholderText("Confirm Password"), { target: { value: "Password123!" } });
+    fireEvent.click(screen.getByRole("button", { name: "Sign Up" }));
+
+    // Wait for verification form
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Enter 6-digit code")).toBeInTheDocument();
+    });
+
+    // Submit wrong code
+    fireEvent.change(screen.getByPlaceholderText("Enter 6-digit code"), { target: { value: "000000" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify Email" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("The verification code is incorrect. Try again.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows submitting state while form is processing", async () => {
+    // Make create hang so we can observe the loading state
+    mockSignUp.create.mockImplementation(() => new Promise(() => {}));
+
+    render(<Signup signUp={mockSignUp} setActive={mockSetActive} isLoaded={true} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Email"), { target: { value: "test@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("Password"), { target: { value: "Password123!" } });
+    fireEvent.change(screen.getByPlaceholderText("Confirm Password"), { target: { value: "Password123!" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign Up" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Submitting..." })).toBeDisabled();
+    });
+  });
+});

--- a/apps/frontend/src/styles/signup.module.css
+++ b/apps/frontend/src/styles/signup.module.css
@@ -169,3 +169,119 @@
     font-size: 2rem;
   }
 }
+
+/* VERIFICATION CARD */
+.verificationCard {
+  width: 100%;
+  max-width: 480px;
+  background: #402479;
+  border-radius: 28px;
+  padding: 56px 48px;
+  box-shadow: 0 10px 40px rgba(64, 36, 121, 0.15);
+  text-align: center;
+}
+
+.verificationTitle {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 0 0 12px;
+}
+
+.verificationSubtitle {
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.8);
+  margin: 0 0 32px;
+  line-height: 1.5;
+}
+
+.verificationSubtitle strong {
+  color: #e3af64;
+}
+
+.verificationLabel {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #e3af64;
+  margin-bottom: 8px;
+  text-align: left;
+}
+
+.verificationInput {
+  width: 100%;
+  height: 52px;
+  border: 1.5px solid rgba(255, 255, 255, 0.2);
+  border-radius: 14px;
+  padding: 0 16px;
+  font-size: 1.25rem;
+  letter-spacing: 4px;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+  outline: none;
+  box-sizing: border-box;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.verificationInput::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+  letter-spacing: normal;
+  font-size: 1rem;
+}
+
+.verificationInput:focus {
+  border-color: #e3af64;
+  box-shadow: 0 0 0 4px rgba(227, 175, 100, 0.15);
+}
+
+.verificationError {
+  margin: 12px 0;
+  font-size: 0.95rem;
+  color: #ffb3b3;
+  text-align: left;
+}
+
+.verificationButton {
+  margin-top: 24px;
+  width: 100%;
+  height: 52px;
+  border: none;
+  border-radius: 14px;
+  background: #e3af64;
+  color: #402479;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 22px rgba(227, 175, 100, 0.25);
+  transition:
+    background-color 0.2s ease,
+    transform 0.15s ease,
+    box-shadow 0.2s ease;
+}
+
+.verificationButton:hover {
+  background: #d89f4f;
+  transform: translateY(-1px);
+}
+
+.verificationButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+@media (max-width: 900px) {
+  .verificationCard {
+    padding: 36px 24px;
+  }
+
+  .verificationTitle {
+    font-size: 1.5rem;
+  }
+}


### PR DESCRIPTION
- Switch useSignUp import to @clerk/nextjs/legacy to fix isLoaded never becoming true
- Redirect to /auth/login after successful email verification
- Restyle verification code form with purple card matching design system
- Add comprehensive tests for Login and Signup components (22 tests)

## Developer: {Kai}

Closes #{105}

### Pull Request Summary

Fixed the signup flow by switching useSignUp to the legacy Clerk import, which resolves the hook never loading. Restyled the email verification screen with a purple card matching the app's design and redirected users to the login page after verification. Added 22 tests covering both Login and Signup components.

### Modifications

- \`apps/frontend/src/app/Auth/SignUp/page.tsx\` — switched to legacy import
- \`apps/frontend/src/components/auth/Signup.tsx\` — updated redirect, new verification UI markup
- \`apps/frontend/src/styles/signup.module.css\` — added verification card styles

### Testing Considerations

- Added \`Login.test.tsx\` (12 tests) and \`Signup.test.tsx\` (10 tests) covering form rendering, validation, Clerk interactions, error handling, and redirects
- All 22 tests passing"

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="1372" height="833" alt="Screenshot 2026-05-12 at 8 24 57 PM" src="https://github.com/user-attachments/assets/76d48ca4-3750-4824-994a-e9143f91f54a" />
