### PR TITLE
replaced Much Hope text with a logo image and changed styling to make…

### DIFF
--- a/apps/frontend/src/components/LandingPage.tsx
+++ b/apps/frontend/src/components/LandingPage.tsx
@@ -54,9 +54,8 @@ export default function LandingPage() {
       <section className={styles.heroContainer}>
         <div className={styles.overlay}>
           <h1 className={styles.title}>Join us in serving local communities in need!</h1>
-          <Link href="/auth/login" className={styles.ctaButton}>
-            <h1 className={styles.title}>MuchHope</h1>
-            <p className={styles.subtitle}>Providing resources and support for the homeless community in San Jose.</p>
+          <Link href="/auth/login" className={styles.logoLink}>
+            <img src="/color-logo.png" alt="MuchHope" className={styles.logoImage} />
           </Link>
           <Link href="/Events/Upcoming" className={styles.ctaButton}>
             Volunteer

--- a/apps/frontend/src/styles/landingPage.module.css
+++ b/apps/frontend/src/styles/landingPage.module.css
@@ -27,11 +27,14 @@ body {
 }
 
 .overlay {
-  background-color: rgba(46, 16, 67, 0.65);
+  background-color: rgba(80, 40, 120, 0.55);
   padding: 60px 40px;
   border-radius: 16px;
   text-align: center;
   max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .title {
@@ -47,6 +50,20 @@ body {
   margin: 0 0 40px 0;
   line-height: 1.5;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.logoLink {
+  display: block;
+  margin: 0 auto 24px auto;
+  text-align: center;
+}
+
+.logoImage {
+  height: 180px;
+  width: auto;
+  object-fit: contain;
+  display: block;
+  margin: 0 auto;
 }
 
 .ctaButton {


### PR DESCRIPTION
… the logo more visible

## Developer: Farid Rohana

Closes #99

### Pull Request Summary

Replaced the "MuchHope" text button on the landing page with the actual color-logo.png image.  The overlay background was also adjusted from the original dark purple to a lighter medium purple to provide enough contrast for the logo to be visible while keeping the site's color scheme.

### Modifications

- LandingPage.tsx
- landingPage.module.css

### Testing Considerations

the "MuchHope" text no longer appears on the landing page and is now a logo.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="845" height="427" alt="image" src="https://github.com/user-attachments/assets/2e95c42f-8b67-407d-bdae-0ff2006727ff" />
