### PR TITLE
Feat: Make breadcrumb headers look like Admin >Manage Users  from issue 98

### DIFF
--- a/apps/frontend/src/app/Events/PastEvents/page.tsx
+++ b/apps/frontend/src/app/Events/PastEvents/page.tsx
@@ -2,6 +2,7 @@
 
 // src/app/events/pastevents
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import AuthLayout from "../../AuthLayout";
 import styles from "../../../styles/pastEvents.module.css";
 import EventCard from "../../../components/EventCard";
@@ -47,8 +48,15 @@ export default function PastEventsPage() {
 
   return (
     <AuthLayout>
-      <div className={styles.hero}>
-        <h1 className={styles.heroTitle}>View Our Past Events!</h1>
+      <div className={styles.pageHeader}>
+        <div className={styles.breadcrumb}>
+          <Link href="/Events/Upcoming" className={styles.breadcrumbLink}>
+            My Events
+          </Link>
+          <span className={styles.breadcrumbSeparator}>&gt;</span>
+          <span className={styles.activeBreadcrumb}>Past Events</span>
+        </div>
+        <h1 className={styles.pageTitle}>Past Events</h1>
       </div>
       <main className={styles.mainContent}>
         {isLoading && <p className={styles.loadingText}>Loading past events...</p>}

--- a/apps/frontend/src/app/Events/Upcoming/page.tsx
+++ b/apps/frontend/src/app/Events/Upcoming/page.tsx
@@ -175,10 +175,13 @@ export default function UpcomingEventsPage() {
 
   return (
     <AuthLayout>
-      <div className={styles.hero}>
-        <h1 className={styles.heroTitle}>
-          {isMainAdmin ? "Add to Upcoming Events!" : "Here are some upcoming events!"}
-        </h1>
+      <div className={styles.pageHeader}>
+        <div className={styles.breadcrumb}>
+          <span className={styles.breadcrumbLink}>My Events</span>
+          <span className={styles.breadcrumbSeparator}>&gt;</span>
+          <span className={styles.activeBreadcrumb}>Upcoming Events</span>
+        </div>
+        <h1 className={styles.pageTitle}>Upcoming Events</h1>
       </div>
       <main className={styles.mainContent}>
         {isMainAdmin && (

--- a/apps/frontend/src/app/Profile/page.tsx
+++ b/apps/frontend/src/app/Profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useUser } from "@clerk/nextjs";
+import Link from "next/link";
 import AuthLayout from "../AuthLayout";
 import ProfileForm from "../../components/volunteer/Profile";
 import UpcomingShifts from "../../components/UpcomingShifts";
@@ -31,7 +32,14 @@ export default function ProfilePage() {
   return (
     <AuthLayout hideFooter>
       <div className={styles.pageContainer}>
-        <h1 className={styles.pageTitle}>Volunteer Dashboard</h1>
+        <div className={styles.breadcrumb}>
+          <Link href="/" className={styles.breadcrumbLink}>
+            Home
+          </Link>
+          <span className={styles.breadcrumbSeparator}>&gt;</span>
+          <span className={styles.activeBreadcrumb}>My Profile</span>
+        </div>
+        <h1 className={styles.pageTitle}>My Profile</h1>
         <div className={styles.profileHeader}>
           <div className={styles.photoContainer}>
             {photoUrl ? (

--- a/apps/frontend/src/app/admin/profile/page.tsx
+++ b/apps/frontend/src/app/admin/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useUser } from "@clerk/nextjs";
+import Link from "next/link";
 import AuthLayout from "../../AuthLayout";
 import AdminProfile from "../../../components/admin/AdminProfile";
 import styles from "../../../styles/adminprofile.module.css";
@@ -30,7 +31,14 @@ export default function ProfilePage() {
   return (
     <AuthLayout hideFooter>
       <div className={styles.pageContainer}>
-        <h1 className={styles.pageTitle}>Admin Dashboard</h1>
+        <div className={styles.breadcrumb}>
+          <Link href="/admin" className={styles.breadcrumbLink}>
+            Admin
+          </Link>
+          <span className={styles.breadcrumbSeparator}>&gt;</span>
+          <span className={styles.activeBreadcrumb}>My Profile</span>
+        </div>
+        <h1 className={styles.pageTitle}>My Profile</h1>
         <div className={styles.profileHeader}>
           <div className={styles.photoContainer}>
             {photoUrl ? (

--- a/apps/frontend/src/styles/adminprofile.module.css
+++ b/apps/frontend/src/styles/adminprofile.module.css
@@ -5,11 +5,38 @@
   box-sizing: border-box;
 }
 
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 18px;
+  font-size: 13px;
+  color: #8c8c8c;
+}
+
+.breadcrumbLink {
+  color: #8c8c8c;
+  text-decoration: none;
+}
+
+.breadcrumbLink:hover {
+  text-decoration: underline;
+}
+
+.breadcrumbSeparator {
+  color: #b0b0b0;
+}
+
+.activeBreadcrumb {
+  color: #5c4b8a;
+  font-weight: 500;
+}
+
 .pageTitle {
   font-size: 2rem;
   font-weight: 700;
-  margin-bottom: 2rem;
-  color: #111;
+  color: #181818;
+  margin: 0 0 2rem;
 }
 
 .profileHeader {

--- a/apps/frontend/src/styles/pastEvents.module.css
+++ b/apps/frontend/src/styles/pastEvents.module.css
@@ -19,22 +19,42 @@
   margin-left: 60px;
 }
 
-.hero {
-  width: 100%;
-  padding: 3rem 2rem;
-  background-color: #d9d9d9;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-sizing: border-box;
-  margin: 0;
+.pageHeader {
+  padding: 2rem 2rem 0;
 }
 
-.heroTitle {
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 18px;
+  font-size: 13px;
+  color: #8c8c8c;
+}
+
+.breadcrumbLink {
+  color: #8c8c8c;
+  text-decoration: none;
+}
+
+.breadcrumbLink:hover {
+  text-decoration: underline;
+}
+
+.breadcrumbSeparator {
+  color: #b0b0b0;
+}
+
+.activeBreadcrumb {
+  color: #5c4b8a;
+  font-weight: 500;
+}
+
+.pageTitle {
   font-size: 2rem;
   font-weight: 700;
-  color: #555;
-  margin: 0;
+  color: #181818;
+  margin: 0 0 1.5rem;
 }
 
 .pastEventsList {

--- a/apps/frontend/src/styles/profile.module.css
+++ b/apps/frontend/src/styles/profile.module.css
@@ -7,11 +7,38 @@
   box-sizing: border-box;
 }
 
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 18px;
+  font-size: 13px;
+  color: #8c8c8c;
+}
+
+.breadcrumbLink {
+  color: #8c8c8c;
+  text-decoration: none;
+}
+
+.breadcrumbLink:hover {
+  text-decoration: underline;
+}
+
+.breadcrumbSeparator {
+  color: #b0b0b0;
+}
+
+.activeBreadcrumb {
+  color: #5c4b8a;
+  font-weight: 500;
+}
+
 .pageTitle {
   font-size: 2rem;
   font-weight: 700;
-  color: #000000;
-  margin-bottom: 2rem;
+  color: #181818;
+  margin: 0 0 2rem;
 }
 
 /* Profile Header */

--- a/apps/frontend/src/styles/upcomingEvents.module.css
+++ b/apps/frontend/src/styles/upcomingEvents.module.css
@@ -25,20 +25,42 @@
   padding-bottom: 4rem;
 }
 
-.hero {
-  width: 100%;
-  padding: 3rem 2rem;
-  display: flex;
-  align-items: left;
-  justify-content: left;
-  box-sizing: border-box;
+.pageHeader {
+  padding: 2rem 2rem 0;
 }
 
-.heroTitle {
-  font-size: 2.4rem;
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 18px;
+  font-size: 13px;
+  color: #8c8c8c;
+}
+
+.breadcrumbLink {
+  color: #8c8c8c;
+  text-decoration: none;
+}
+
+.breadcrumbLink:hover {
+  text-decoration: underline;
+}
+
+.breadcrumbSeparator {
+  color: #b0b0b0;
+}
+
+.activeBreadcrumb {
+  color: #5c4b8a;
+  font-weight: 500;
+}
+
+.pageTitle {
+  font-size: 2rem;
   font-weight: 700;
-  color: black;
-  margin: 0;
+  color: #181818;
+  margin: 0 0 1.5rem;
 }
 
 .eventGrid {


### PR DESCRIPTION
## Developer: Caleb So

Closes #98 

### Pull Request Summary

- Added headers to all pages when user is logged in similar to the Admin > Manage Users page
  - http://localhost:3000/Profile
  - http://localhost:3000/Events/Upcoming
  - http://localhost:3000/Events/PastEvents
  - http://localhost:3000/admin/profile
- Other pages such as About Us are not for logged in users, I did not change

### Modifications
-  apps/frontend/src/app/Events/PastEvents/page.tsx
- apps/frontend/src/app/Events/Upcoming/page.tsx
- apps/frontend/src/app/Profile/page.tsx
- apps/frontend/src/app/admin/profile/page.tsx
- apps/frontend/src/styles/adminprofile.module.css
- apps/frontend/src/styles/pastEvents.module.css 
- apps/frontend/src/styles/profile.module.css
- apps/frontend/src/styles/upcomingEvents.module.css


### Testing Considerations

- N/A

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
<img width="732" height="406" alt="000933" src="https://github.com/user-attachments/assets/2e158be3-f2e1-403d-8a06-8abdd6317086" />
<img width="732" height="406" alt="000934" src="https://github.com/user-attachments/assets/c778cde9-30a7-4afd-b297-d020161b3016" />
<img width="732" height="406" alt="000935" src="https://github.com/user-attachments/assets/51a9def2-4a78-4612-abd1-ca559ff0bfe5" />
<img width="732" height="406" alt="000936" src="https://github.com/user-attachments/assets/7ae24fbc-a1ad-46e2-92a2-b3efbb54b73c" />
