### PR TITLE
updated Past Events UI to match site styling

### DIFF
--- a/apps/frontend/src/app/Events/PastEvents/page.tsx
+++ b/apps/frontend/src/app/Events/PastEvents/page.tsx
@@ -68,7 +68,7 @@ export default function PastEventsPage() {
             <span className={styles.activeBreadcrumb}>Past Events</span>
           </div>
           <h1 className={styles.heroTitle}>Past Events</h1>
-          <p className={styles.heroSubtitle}>Browse events that have already taken place</p>
+          <p className={styles.heroSubtitle}>Look at past events you have volunteered for</p>
         </section>
 
         {isLoading && <p className={styles.loadingText}>Loading past events...</p>}

--- a/apps/frontend/src/styles/pastEvents.module.css
+++ b/apps/frontend/src/styles/pastEvents.module.css
@@ -1,12 +1,16 @@
-.pageLayout {
-  min-height: 100vh;
+:root {
+  --mh-bg: #f8f6f7;
+  --mh-purple: #402479;
+  --mh-gold: #e3af64;
+  --mh-cream: #ffe9ac;
+  --mh-ink: #212121;
 }
 
 .mainContent {
   min-height: 100vh;
   padding: 54px 42px 64px;
   box-sizing: border-box;
-  background: #f8f6f7;
+  background: var(--mh-bg);
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
@@ -44,7 +48,7 @@
 
 .heroTitle {
   margin: 0;
-  color: #402479;
+  color: var(--mh-purple);
   font-size: clamp(2rem, 4vw, 3.1rem);
   font-weight: 700;
   line-height: 1.1;
@@ -54,11 +58,6 @@
   margin: 12px 0 0;
   color: #373737;
   font-size: clamp(1rem, 2vw, 1.2rem);
-}
-
-.pastEventsList {
-  padding: 2rem;
-  max-width: 900px;
 }
 
 .eventGrid {
@@ -72,12 +71,32 @@
 .loadingText,
 .errorText,
 .emptyText {
-  text-align: center;
-  padding: 2rem;
-  color: #333333;
+  margin: 0;
+  color: #444;
   font-size: 1rem;
 }
 
 .errorText {
-  color: #721c24;
+  padding: 0.9rem 1rem;
+  border-radius: 10px;
+  background: #fdeaea;
+  color: #a12626;
+  border: 1px solid #f2bcbc;
+}
+
+@media (max-width: 1100px) {
+  .eventGrid {
+    gap: 26px;
+  }
+}
+
+@media (max-width: 900px) {
+  .mainContent {
+    padding: 30px 18px 42px;
+  }
+
+  .eventGrid {
+    grid-template-columns: 1fr;
+    gap: 22px;
+  }
 }


### PR DESCRIPTION
## Developer: Farid Rohana

Closes #113

### Pull Request Summary

Updated the Past Events page UI to be visually cohesive with the rest of the site. The page previously had inconsistent styling compared to the Upcoming Events page - hardcoded color values, missing responsive breakpoints, and a generic subtitle. This PR brings it in line with the shared design.

### Modifications

pastEvents.module.css : replaced hardcoded hex values with shared CSS custom properties (--mh-purple, --mh-bg, etc.), added responsive breakpoints so the event grid collapses to a single column on smaller screens

apps/frontend/src/app/Events/PastEvents/page.tsx : updated subtitle from "Browse events that have already taken place" to "Look at past events you have volunteered for" to match the tone of the site.

### Testing Considerations

To verify the layout with real content, I added temporary mock data. This allowed visual testing of the 2-column event grid, card rendering, and responsive behaviour without needing the backend running. The mock data was removed before this PR was pushed.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
<img width="1258" height="633" alt="image" src="https://github.com/user-attachments/assets/1d9c2267-4b18-45e7-941d-ae0fb1994ff4" />
