### PR TITLE
fix: create volunteer record in MongoDB after signup verification

### DIFF
--- a/apps/frontend/src/components/auth/Signup.tsx
+++ b/apps/frontend/src/components/auth/Signup.tsx
@@ -243,6 +243,19 @@ export default function Signup({ signUp, setActive, isLoaded }: SignupProps) {
           session: signUpAttempt.createdSessionId,
         });
 
+        await fetch("/api/volunteers", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            firstName: formData.firstName,
+            lastName: formData.lastName,
+            email: formData.email,
+            clerkId: signUpAttempt.createdUserId,
+            isAdult: formData.age === "Yes",
+            userType: "Volunteer",
+          }),
+        });
+
         // Go to home after successful signup
         router.push("/");
       } else {

--- a/apps/frontend/src/components/auth/__tests__/Signup.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/Signup.test.tsx
@@ -8,6 +8,12 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 
+// Mock fetch for the POST /api/volunteers call after signup
+global.fetch = vi.fn().mockResolvedValue({
+  ok: true,
+  json: async () => ({}),
+}) as any;
+
 // Mock AuthLayout to just render children
 vi.mock("@/app/AuthLayout", () => ({
   default: ({ children }: { children: React.ReactNode }) => <div data-testid="auth-layout">{children}</div>,
@@ -156,7 +162,7 @@ describe("Signup", () => {
     });
 
     expect(mockSetActive).toHaveBeenCalledWith({ session: "session_123" });
-    expect(mockPush).toHaveBeenCalledWith("/auth/login");
+    expect(mockPush).toHaveBeenCalledWith("/");
   });
 
   it("shows error when signUp.create fails with known error code", async () => {
@@ -266,7 +272,7 @@ describe("Signup", () => {
       });
     });
 
-    it("completes full flow: create account → verify email → activate session → redirect to login", async () => {
+    it("completes full flow: create account → verify email → activate session → redirect to home", async () => {
       const createdSessionId = "sess_new_user_abc123";
       mockSignUp.attemptEmailAddressVerification.mockResolvedValue({
         status: "complete",
@@ -320,7 +326,7 @@ describe("Signup", () => {
 
       // Step 8: User is redirected to login page
       expect(mockPush).toHaveBeenCalledTimes(1);
-      expect(mockPush).toHaveBeenCalledWith("/auth/login");
+      expect(mockPush).toHaveBeenCalledWith("/");
     });
 
     it("account creation is called before verification — correct order of operations", async () => {


### PR DESCRIPTION
## Developer: Caleb So

Closes #136

### Pull Request Summary

Fixes a bug where completing the signup flow created a Clerk account but never saved a volunteer record to MongoDB, causing all database-dependent features (profile, shift history, admin user management) to silently fail for self-registered users.

### Modifications

- apps/frontend/src/components/auth/Signup.tsx: after successful email verification, added a POST /api/volunteers call with the user's name, email, Clerk ID, and isAdult value before redirecting home

### Testing Considerations

- Sign up with a new email address and verify the email code
- Log in as a mainadmin and go to /admin/manage-users
- The newly registered user should appear in the volunteer list
- Without this fix, the user would be absent from the list despite having a valid Clerk account
- Reviewer should also confirm that if the POST fails (e.g. missing MONGO_URI), the user still lands on the home page without a crash

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

N/A
