### PR TITLE
feat: add admin shift view for managing event volunteers (issue #129)

### DIFF
--- a/apps/backend/src/routes/shiftRoutes.js
+++ b/apps/backend/src/routes/shiftRoutes.js
@@ -4,9 +4,35 @@ const { getModels } = require("../../database/initModels");
 
 router.get("/", async (req, res) => {
   try {
-    const { Shift } = getModels();
-    const { email } = req.query;
-    if (!email) return res.status(400).json({ message: "email query param is required" });
+    const { Shift, Volunteer } = getModels();
+    const { email, eventId } = req.query;
+
+    // Admin view: return all shifts for an event, enriched with volunteer display names
+    if (eventId) {
+      const shifts = await Shift.find({ eventId }).lean();
+
+      // Deduplicate emails before querying, since one volunteer may have multiple shifts
+      const emails = [...new Set(shifts.map((s) => s.volunteerEmail))];
+
+      // Batch lookup: one DB query for all volunteers instead of one per shift
+      const volunteers = await Volunteer.find({ email: { $in: emails } }).lean();
+
+      // Build a map so each shift lookup is O(1) instead of scanning the array
+      const volunteerMap = Object.fromEntries(volunteers.map((v) => [v.email, v]));
+
+      const enriched = shifts.map((shift) => {
+        const vol = volunteerMap[shift.volunteerEmail];
+        return {
+          ...shift,
+          // Volunteers are stored in a separate DB (volunteersDB vs eventsDB), so vol may be
+          // undefined if the record hasn't synced. Fall back to email as a readable identifier.
+          volunteerName: vol ? `${vol.firstName} ${vol.lastName}` : shift.volunteerEmail,
+        };
+      });
+      return res.status(200).json(enriched);
+    }
+
+    if (!email) return res.status(400).json({ message: "email or eventId query param is required" });
 
     const now = new Date();
     const shifts = await Shift.find({ volunteerEmail: email }).lean();

--- a/apps/frontend/src/app/Events/Upcoming/page.tsx
+++ b/apps/frontend/src/app/Events/Upcoming/page.tsx
@@ -8,6 +8,7 @@ import styles from "../../../styles/upcomingEvents.module.css";
 import EventCard from "../../../components/EventCard";
 import EventInfoPopUp from "../../../components/EventInfoPopUp";
 import ShiftSelectionPopUp from "../../../components/ShiftSelectionPopUp";
+import AdminShiftViewPopUp from "../../../components/AdminShiftViewPopUp";
 import AuthLayout from "../../AuthLayout";
 import { useIsSuperAdmin, useIsAdmin } from "../../../../lib/roles";
 
@@ -29,7 +30,7 @@ interface SubEvent {
   description: string;
 }
 
-type ModalState = "none" | "moreInfo" | "shiftSelect";
+type ModalState = "none" | "moreInfo" | "shiftSelect" | "adminShiftView";
 
 type EventFormState = {
   title: string;
@@ -114,7 +115,7 @@ export default function UpcomingEventsPage() {
       return;
     }
     setSelectedEvent(event);
-    setModalState("moreInfo");
+    setModalState(isAdminUser ? "adminShiftView" : "moreInfo");
   };
 
   const closeModal = () => {
@@ -402,6 +403,10 @@ export default function UpcomingEventsPage() {
           onClose={closeModal}
           onSave={handleSaveShift}
         />
+      )}
+
+      {modalState === "adminShiftView" && selectedEvent && (
+        <AdminShiftViewPopUp event={selectedEvent} onClose={closeModal} />
       )}
     </AuthLayout>
   );

--- a/apps/frontend/src/app/api/shifts/route.ts
+++ b/apps/frontend/src/app/api/shifts/route.ts
@@ -5,13 +5,19 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const email = searchParams.get("email");
+  const eventId = searchParams.get("eventId");
 
-  if (!email) {
-    return NextResponse.json({ message: "email query param is required" }, { status: 400 });
+  if (!email && !eventId) {
+    return NextResponse.json({ message: "email or eventId query param is required" }, { status: 400 });
   }
 
   const url = new URL(`${API_BASE}/shifts`);
-  url.searchParams.set("email", email);
+  // eventId is not restricted at the API level, but only AdminShiftViewPopUp calls this path
+  if (eventId) {
+    url.searchParams.set("eventId", eventId);
+  } else {
+    url.searchParams.set("email", email!);
+  }
 
   try {
     const res = await fetch(url.toString(), { cache: "no-store" });

--- a/apps/frontend/src/components/AdminShiftViewPopUp.tsx
+++ b/apps/frontend/src/components/AdminShiftViewPopUp.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "../styles/adminShiftViewPopUp.module.css";
+
+// TODO: hardcoded placeholder; shift types and their order should come from the database
+const SHIFT_ORDER = ["Setup", "Cooking", "Serving", "Clean Up"];
+
+interface ShiftRecord {
+  _id: string;
+  eventId: string;
+  volunteerId: string;
+  volunteerEmail: string;
+  volunteerName: string;
+  shiftType: string;
+  shiftTime: string;
+  date: string;
+}
+
+interface EventData {
+  id: string;
+  title: string;
+  date: string;
+}
+
+interface AdminShiftViewPopUpProps {
+  event: EventData;
+  onClose: () => void;
+}
+
+export default function AdminShiftViewPopUp({ event, onClose }: AdminShiftViewPopUpProps) {
+  const [shifts, setShifts] = useState<ShiftRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchShifts() {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const res = await fetch(`/api/shifts?eventId=${encodeURIComponent(event.id)}`, {
+          cache: "no-store",
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.message || "Failed to load shifts");
+        setShifts(Array.isArray(data) ? data : []);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load shifts");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    fetchShifts();
+  }, [event.id]);
+
+  const handleRemove = async (shiftId: string) => {
+    setRemovingId(shiftId);
+    try {
+      const res = await fetch(`/api/shifts?id=${encodeURIComponent(shiftId)}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || "Failed to remove volunteer");
+      }
+      setShifts((prev) => prev.filter((s) => s._id !== shiftId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove volunteer");
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  // All shifts of the same type share the same time, so grab it from the first match
+  const grouped = SHIFT_ORDER.map((type) => ({
+    type,
+    time: shifts.find((s) => s.shiftType === type)?.shiftTime ?? "",
+    volunteers: shifts.filter((s) => s.shiftType === type),
+  }));
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <button className={styles.closeButton} onClick={onClose}>
+          ×
+        </button>
+        <h2 className={styles.title}>Volunteer Shifts</h2>
+        <p className={styles.subtitle}>
+          {event.title} &mdash; {event.date}
+        </p>
+
+        {isLoading && <p className={styles.loading}>Loading shifts...</p>}
+        {error && <p className={styles.error}>{error}</p>}
+
+        {!isLoading &&
+          !error &&
+          (shifts.length === 0 ? (
+            <p className={styles.empty}>No volunteers have signed up yet.</p>
+          ) : (
+            grouped.map(({ type, time, volunteers }) => (
+              <div key={type} className={styles.shiftGroup}>
+                <div className={styles.shiftGroupHeader}>
+                  <h3 className={styles.shiftGroupTitle}>{type}</h3>
+                  {time && <span className={styles.shiftGroupTime}>{time}</span>}
+                </div>
+                {volunteers.length === 0 ? (
+                  <p className={styles.noVolunteers}>No volunteers</p>
+                ) : (
+                  <ul className={styles.volunteerList}>
+                    {volunteers.map((shift) => (
+                      <li key={shift._id} className={styles.volunteerItem}>
+                        <div className={styles.volunteerInfo}>
+                          <span className={styles.volunteerName}>{shift.volunteerName}</span>
+                          <span className={styles.volunteerEmail}>{shift.volunteerEmail}</span>
+                        </div>
+                        <button
+                          className={styles.removeButton}
+                          onClick={() => handleRemove(shift._id)}
+                          disabled={removingId === shift._id}
+                        >
+                          {removingId === shift._id ? "Removing..." : "Remove"}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/styles/adminShiftViewPopUp.module.css
+++ b/apps/frontend/src/styles/adminShiftViewPopUp.module.css
@@ -1,0 +1,154 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 12px;
+  padding: 2rem;
+  width: 100%;
+  max-width: 580px;
+  max-height: 80vh;
+  overflow-y: auto;
+  position: relative;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+}
+
+.closeButton {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: #888;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+}
+
+.closeButton:hover {
+  color: #111;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #111;
+  margin: 0 0 0.25rem 0;
+}
+
+.subtitle {
+  font-size: 0.85rem;
+  color: #777;
+  margin: 0 0 1.5rem 0;
+}
+
+.loading {
+  text-align: center;
+  color: #777;
+  padding: 2rem 0;
+}
+
+.error {
+  color: #c0392b;
+  font-size: 0.9rem;
+}
+
+.empty {
+  color: #777;
+  font-size: 0.9rem;
+  padding: 1rem 0;
+}
+
+.shiftGroup {
+  margin-bottom: 1.5rem;
+}
+
+.shiftGroupHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.shiftGroupTitle {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #402479;
+  margin: 0;
+}
+
+.shiftGroupTime {
+  font-size: 0.8rem;
+  color: #888;
+}
+
+.volunteerList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.volunteerItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 0.6rem 0.9rem;
+}
+
+.volunteerInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.volunteerName {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #111;
+}
+
+.volunteerEmail {
+  font-size: 0.78rem;
+  color: #777;
+}
+
+.removeButton {
+  padding: 0.3rem 0.85rem;
+  background-color: #c0392b;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  font-family: inherit;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.removeButton:hover:not(:disabled) {
+  background-color: #a93226;
+}
+
+.removeButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.noVolunteers {
+  font-size: 0.85rem;
+  color: #aaa;
+  padding: 0.4rem 0;
+}


### PR DESCRIPTION
## Developer: Caleb So

Closes #129 

### Pull Request Summary

Implements an admin-only shift management view for upcoming events. When an admin clicks "View Shifts" on an event card, they now see a popup listing all signed-up volunteers grouped by shift type (Setup, Cooking, Serving, Clean Up), with the ability to remove any volunteer from a shift. Regular volunteers continue to see the existing registration modal unchanged.

### Modifications

- `apps/backend/src/routes/shiftRoutes.js` - added `?eventId=` query support to GET /shifts; returns all shifts for an event enriched with volunteer display names via batch lookup
- `apps/frontend/src/app/api/shifts/route.ts` - extended the Next.js proxy to forward `?eventId=` to the backend
- `apps/frontend/src/components/AdminShiftViewPopUp.tsx` - new component; fetches shifts by eventId, groups by shift type, and allows admins to remove volunteers via DELETE
- `apps/frontend/src/styles/adminShiftViewPopUp.module.css` - styles for the new popup
- `apps/frontend/src/app/Events/Upcoming/page.tsx` - routes admins to the new AdminShiftViewPopUp instead of the volunteer EventInfoPopUp when clicking "View Shifts"

### Testing Considerations

- Verify a volunteer can sign up and appears in the admin view:
  - Log in as a volunteer and click "Register" on an event
  - Select a shift and complete registration
  - Log in as an admin and click "View Shifts" on the same event
  - Verify the volunteer appears under the correct shift group with name and email shown

- Verify an admin can remove a volunteer from a shift:
  - In the admin shift view, click Remove next to a volunteer
  - Verify the volunteer disappears from the list immediately
  - Re-open the shift view and verify the volunteer is still gone after refresh
   
Known limitation: shift types (Setup, Cooking, Serving, Clean Up) and their times are currently hardcoded in both AdminShiftViewPopUp and ShiftSelectionPopUp. Making these database-driven per event requires model, backend, and UI changes and is out of scope for this PR.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast


<img width="1391" height="930" alt="001002" src="https://github.com/user-attachments/assets/3c2241f8-6029-4a42-85ae-3e7fb3b937c7" />
<img width="1391" height="930" alt="001003" src="https://github.com/user-attachments/assets/46341cad-2492-4b1f-b1c8-88f1dc51c82c" />

